### PR TITLE
bugfix for crashing in 0 input channels case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(PedalSynth)
 
 find_package(OpenGL REQUIRED)
 

--- a/PedalApp.cpp
+++ b/PedalApp.cpp
@@ -123,14 +123,25 @@ PedalApp* createApp(defaultCallback callback){
   outputParameters.nChannels = app->output_channels;
   outputParameters.firstChannel = 0;
   RtAudio::StreamParameters inputParameters;
-  inputParameters.deviceId = app->device_id;
-  inputParameters.nChannels = app->input_channels;
-  inputParameters.firstChannel = 0;
+  auto* inparams = &inputParameters;
+  if (app->input_channels > 0) {
+    inputParameters.deviceId = app->device_id;
+    inputParameters.nChannels = app->input_channels;
+    inputParameters.firstChannel = 0;
+  }
+  else {
+    // cannot open stream with 0 channels so pass nullptr in that case
+    inparams = nullptr;
+  }
   try {
-    app->rtaudio.openStream(&outputParameters, &inputParameters, RTAUDIO_FLOAT32,
-                          app->sampling_rate, &app->buffer_size,
-                          audioCallback, app,
-                          nullptr, nullptr); // option & error callback
+    app->rtaudio.openStream(&outputParameters,
+                            inparams,
+                            RTAUDIO_FLOAT32,
+                            app->sampling_rate,
+                            &app->buffer_size,
+                            audioCallback, app,
+                            nullptr, // options
+                            nullptr); // error callback
   }
   catch (RtAudioError& e) {
     e.printMessage();


### PR DESCRIPTION
If the number of channels is 0 the stream parameter cannot be passed to open stream function. In that case passing nullptr is needed. This pull request fixes that issue by checking number of channels and conditionally passing nullptr in 0 channels case.

Plus, adds project name to the CMakeLists.txt to remove no project name warning